### PR TITLE
Manifest updated to use autoclustering

### DIFF
--- a/cyclos-4-cluster/manifest.jps
+++ b/cyclos-4-cluster/manifest.jps
@@ -42,7 +42,6 @@ env:
        - cloudlets: 8
          count: 2
          nodeType: postgresql
-         tag: 9.6.11
        - nodeType: nginx
          count: 1
          cloudlets: 8

--- a/cyclos-4-cluster/manifest.jps
+++ b/cyclos-4-cluster/manifest.jps
@@ -42,8 +42,8 @@ env:
        - cloudlets: 8
          count: 2
          nodeType: postgresql
+         cluster: true
        - nodeType: nginx
-         count: 1
          cloudlets: 8
          nodeGroup: bl
          displayName: Load balancer
@@ -54,7 +54,6 @@ env:
       - stopEvent
 
 onInstall:
-    - ConfigReplication
     - ConfigDB
     - deploy:
         archive: https://license.cyclos.org/downloads/cyclos/${settings.version}.zip
@@ -65,17 +64,6 @@ onInstall:
       - nodeGroup: cp
 
 actions:
-    resetingNodePassword:
-     - script:
-        script: https://raw.githubusercontent.com/jelastic-jps/cyclos/master/scripts/resetNodePassword.js
-    log: Config replication
-    ConfigReplication:
-      - cmd[sqldb]:
-          - wget "https://raw.githubusercontent.com/jelastic-jps/cyclos/master/scripts/execCmdScript.sh" -O /var/lib/pgsql/script.sh 2>&1
-      - cmd[${nodes.sqldb[0].id}]:
-        - bash -x /var/lib/pgsql/script.sh master ${nodes.sqldb[1].address} ${nodes.sqldb.password} ${nodes.sqldb[0].address} 1>> /var/lib/pgsql/log.log 2>>/var/lib/pgsql/log.log
-      - cmd[${nodes.sqldb[1].id}]:
-        - bash -x /var/lib/pgsql/script.sh slave ${nodes.sqldb[1].address} ${nodes.sqldb.password} ${nodes.sqldb[0].address} 1>> /var/lib/pgsql/log.log 2>>/var/lib/pgsql/log.log
     
     ConfigDB:
      - cmd[${nodes.sqldb[0].id}]: PGPASSWORD=${nodes.sqldb.password} psql -Uwebadmin postgres -c "create database cyclos4;"

--- a/cyclos-4-cluster/manifest.jps
+++ b/cyclos-4-cluster/manifest.jps
@@ -1,5 +1,5 @@
 jpsType: install
-jpsVersion: '1.7+'
+jpsVersion: '1.5'
 name: Cyclos 4 PRO Cluster
 id: cyclos-cluster
 categories:

--- a/cyclos-4-cluster/manifest.jps
+++ b/cyclos-4-cluster/manifest.jps
@@ -40,6 +40,7 @@ env:
          scalingMode: CLONE
          links: sqldb:DB
        - cloudlets: 8
+         count: 2
          nodeType: postgresql
          cluster: true
        - nodeType: nginx

--- a/cyclos-4-cluster/manifest.jps
+++ b/cyclos-4-cluster/manifest.jps
@@ -1,5 +1,5 @@
 jpsType: install
-jpsVersion: '1.4.2'
+jpsVersion: '1.7+'
 name: Cyclos 4 PRO Cluster
 id: cyclos-cluster
 categories:

--- a/cyclos-4-cluster/manifest.jps
+++ b/cyclos-4-cluster/manifest.jps
@@ -40,7 +40,6 @@ env:
          scalingMode: CLONE
          links: sqldb:DB
        - cloudlets: 8
-         count: 2
          nodeType: postgresql
          cluster: true
        - nodeType: nginx
@@ -48,10 +47,6 @@ env:
          nodeGroup: bl
          displayName: Load balancer
     ha: true  
-    onBeforeResetNodePassword[nodeGroup:sqldb]:
-      call:
-      - resetingNodePassword
-      - stopEvent
 
 onInstall:
     - ConfigDB


### PR DESCRIPTION
Manifest is able to use postgresql of versions 9,10,11,12. No database replication configuration scripts required anymore.
Database replication is invoked by autoclustering parameter cluster:true.